### PR TITLE
Display commenter’s name instead of anonymous

### DIFF
--- a/backend/routes/comments.js
+++ b/backend/routes/comments.js
@@ -17,6 +17,7 @@ async function getAllCommentsWithReplies(bookId) {
           id: true,
           first_name: true,
           last_name: true,
+          email: true, // Include email field
         },
       },
     },
@@ -135,6 +136,7 @@ router.post("/", async (req, res) => {
             id: true,
             first_name: true,
             last_name: true,
+            email: true, // Include email field
           },
         },
         parent: true,

--- a/frontend/src/BookModal.jsx
+++ b/frontend/src/BookModal.jsx
@@ -120,10 +120,21 @@ function BookModal({ book, onClose, onJoinDiscussion, isJoined }) {
     }
   };
 
+  // Function to get display name from user data
+  const getDisplayName = (user) => {
+    // use the part of email before @
+    if (user?.email) {
+      return user.email.split("@")[0];
+    }
+
+    // Fallback to Anonymous
+    return "Anonymous";
+  };
+
   const handleReply = (comment) => {
     setReplyingTo(comment);
     setShowCommentForm(true);
-    setNewComment(`@${comment.user?.first_name || "Anonymous"} `);
+    setNewComment(`@${getDisplayName(comment.user)} `);
   };
 
   const cancelReply = () => {
@@ -245,9 +256,7 @@ function BookModal({ book, onClose, onJoinDiscussion, isJoined }) {
           <div className="comment-form">
             {replyingTo && (
               <div className="replying-to">
-                <span>
-                  Replying to {replyingTo.user?.first_name || "Anonymous"}
-                </span>
+                <span>Replying to {getDisplayName(replyingTo.user)}</span>
                 <button onClick={cancelReply} className="cancel-reply-btn">
                   ✕
                 </button>

--- a/frontend/src/components/CommentItem.jsx
+++ b/frontend/src/components/CommentItem.jsx
@@ -33,16 +33,46 @@ const CommentItem = ({
     return "reply-btn deep-nested-reply-btn";
   };
 
+  // Function to get display name from user data
+  const getDisplayName = (user) => {
+    // First try to use first_name if available
+    if (user?.first_name) {
+      return user.first_name;
+    }
+
+    // If no first_name, use the part of email before @
+    if (user?.email) {
+      return user.email.split("@")[0];
+    }
+
+    // Fallback to Anonymous
+    return "Anonymous";
+  };
+
+  // Function to get avatar letter
+  const getAvatarLetter = (user) => {
+    // First try to use first letter of first_name
+    if (user?.first_name && user.first_name.length > 0) {
+      return user.first_name[0].toUpperCase();
+    }
+
+    // If no first_name, use first letter of email
+    if (user?.email && user.email.length > 0) {
+      return user.email[0].toUpperCase();
+    }
+
+    // Fallback to "A" for Anonymous
+    return "A";
+  };
+
   return (
     <div className={nestingLevel === 0 ? "comment" : getReplyClass()}>
       <div className="comment-header">
         <div className="comment-author">
           <div className={getAvatarClass()}>
-            {comment.user?.first_name?.[0] || "A"}
+            {getAvatarLetter(comment.user)}
           </div>
-          <span className="author-name">
-            {comment.user?.first_name || "Anonymous"}
-          </span>
+          <span className="author-name">{getDisplayName(comment.user)}</span>
         </div>
         <span className="comment-time">{formatTime(comment.createdAt)}</span>
       </div>


### PR DESCRIPTION
### Description
- Replaced the default "anonymous" label on comments with the user’s display name or username
- Fallback logic still shows "anonymous" if user data is unavailable


### Test Plan:
<img width="2886" height="1612" alt="image" src="https://github.com/user-attachments/assets/93db142b-00ee-44d2-bbac-a50b72bc2060" />

### Next Steps:
- Implement notifications for replies to a user’s comments


