### PR TITLE
[TC2] Added comment quality check for notifications

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.10.1",
+        "bad-words": "^3.0.4",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
@@ -124,6 +125,24 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/bad-words": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
+      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
+      "license": "MIT",
+      "dependencies": {
+        "badwords-list": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/badwords-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha512-oWhaSG67e+HQj3OGHQt2ucP+vAPm1wTbdp2aDHeuh4xlGXBdWwzZ//pfu6swf5gZ8iX0b7JgmSo8BhgybbqszA==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   "description": "",
   "dependencies": {
     "@prisma/client": "^6.10.1",
+    "bad-words": "^3.0.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",

--- a/backend/see-bad-words.js
+++ b/backend/see-bad-words.js
@@ -1,0 +1,5 @@
+// This is a script to view bad words in`bad-words` package.
+const Filter = require('bad-words');
+const filter = new Filter();
+
+console.log(JSON.stringify(filter.list, null, 2));

--- a/backend/test-comment-filter.js
+++ b/backend/test-comment-filter.js
@@ -1,0 +1,107 @@
+// Import the filter functions
+const {
+  containsBadWords,
+  countWords,
+  shouldCreateNotification,
+} = require("./utils/commentFilters");
+
+// Wait a moment for the filter to initialize
+setTimeout(() => {
+  // Test cases
+  const testCases = [
+    {
+      comment: "This is a normal comment with no bad words",
+      expected: {
+        hasBadWords: false,
+        wordCount: 9,
+        shouldNotify: true, // No bad words and more than 5 words
+      },
+    },
+    {
+      comment: "This comment has a bad word shit but it's longer than 5 words so notification should NOT be sent",
+      expected: {
+        hasBadWords: true,
+        wordCount: 19,
+        shouldNotify: false // Has bad words (should not notify regardless of length)
+      }
+    },
+    {
+      comment: "Short comment",
+      expected: {
+        hasBadWords: false,
+        wordCount: 2,
+        shouldNotify: false, // No bad words, but fewer than 5 words
+      },
+    },
+    {
+      comment: "😊 This 😂 comment 🎉 has 🔥 emojis 👍",
+      expected: {
+        hasBadWords: false,
+        wordCount: 4,
+        shouldNotify: false, // No bad words but fewer than 5 words (excluding emojis)
+      },
+    },
+    {
+      comment: "😊 fuck 😂 you 🎉",
+      expected: {
+        hasBadWords: true,
+        wordCount: 2,
+        shouldNotify: false, // Has bad words (should not notify regardless of length)
+      },
+    },
+    {
+      comment: "This is a perfectly fine comment",
+      expected: {
+        hasBadWords: false,
+        wordCount: 6,
+        shouldNotify: true, // No bad words and more than 5 words
+      },
+    },
+    {
+      comment: "Five words only here pecker",
+      expected: {
+        hasBadWords: true,
+        wordCount: 5,
+        shouldNotify: false, // Has bad words (should not notify regardless of length)
+      },
+    },
+    {
+      comment: "Six words only Test here kawk",
+      expected: {
+        hasBadWords: true,
+        wordCount: 6,
+        shouldNotify: false, // Has bad words (should not notify regardless of length)
+      },
+    },
+  ];
+
+  // Run tests
+  console.log("TESTING COMMENT FILTER FUNCTIONALITY\n");
+
+  testCases.forEach((test, index) => {
+    const hasBadWords = containsBadWords(test.comment);
+    const wordCount = countWords(test.comment);
+    const shouldNotify = shouldCreateNotification(test.comment);
+
+    console.log(`Test Case ${index + 1}: "${test.comment}"`);
+    console.log(
+      `Contains bad words: ${hasBadWords} (Expected: ${test.expected.hasBadWords})`
+    );
+    console.log(
+      `Word count (excluding emojis): ${wordCount} (Expected: ${test.expected.wordCount})`
+    );
+    console.log(
+      `Should create notification: ${shouldNotify} (Expected: ${test.expected.shouldNotify})`
+    );
+
+    const passed =
+      hasBadWords === test.expected.hasBadWords &&
+      wordCount === test.expected.wordCount &&
+      shouldNotify === test.expected.shouldNotify;
+
+    console.log(`Result: ${passed ? "PASSED ✅" : "FAILED ❌"}`);
+    console.log("-----------------------------------");
+  });
+
+  console.log("\nTesting complete!");
+}, 1000); // Wait 1 second for the filter to initialize

--- a/backend/utils/commentFilters.js
+++ b/backend/utils/commentFilters.js
@@ -1,0 +1,79 @@
+// Import the bad-words package
+const Filter = require('bad-words');
+
+// Create a filter instance with default word list
+let filter;
+try {
+  filter = new Filter();
+
+// Adding custom words to the list of bad words for my test cases
+  filter.addWords('foolish', 'stupid');
+
+  console.log('Bad-words filter initialized successfully');
+} catch (error) {
+  console.error('Error initializing bad-words filter:', error);
+}
+
+/**
+ * Checks if a comment contains bad words
+ * @param {string} text - The comment text to check
+ * @returns {boolean} - True if the comment contains bad words
+ */
+const containsBadWords = (text) => {
+  if (!text || typeof text !== 'string') return false;
+
+  try {
+    if (filter) {
+      return filter.isProfane(text);
+    } else {
+      // Fallback if filter initialization failed
+      const commonBadWords = ['fuck', 'shit', 'ass', 'bitch', 'damn', 'foolish'];
+      return commonBadWords.some(word => text.toLowerCase().includes(word));
+    }
+  } catch (error) {
+    console.error('Error checking for bad words:', error);
+    return false;
+  }
+};
+
+/**
+ * Counts the number of words in a text, excluding emojis
+ * @param {string} text - The text to count words in
+ * returns the number of words in the text, excluding emojis
+
+ */
+const countWords = (text) => {
+  if (!text || typeof text !== 'string') return 0;
+
+  // Remove emojis from the text
+  // This regex pattern matches most common emoji characters
+  const textWithoutEmojis = text.replace(/[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/gu, '');
+
+  // Split by whitespace and filter out empty strings
+  const words = textWithoutEmojis.trim().split(/\s+/).filter(word => word.length > 0);
+
+  return words.length;
+};
+
+/**
+ * Determines if a notification should be created for a comment
+ * @param {string} text - The comment text
+ * @param {number} minLength - Minimum word count required (default: 5)
+ * @returns {boolean} - True if notification should be created, false otherwise
+ */
+const shouldCreateNotification = (text, minLength = 5) => {
+  // Don't create notification if:
+  // 1. The comment contains bad words, OR
+  // 2. The comment has fewer than minLength words (excluding emojis)
+  if (containsBadWords(text) || countWords(text) < minLength) {
+    return false;
+  }
+
+  return true;
+};
+
+module.exports = {
+  containsBadWords,
+  countWords,
+  shouldCreateNotification
+};


### PR DESCRIPTION
### Why the change
After a discussion with manager, we decided to increase the complexity and relevance of reply-to-comment notifications. Notifications will now only be sent if replies meet content quality standards — specifically, they must contain at least 5 words (excluding emojis) and must not contain profanity.

### Key Changes:
- Created commentFilters.js utility module with three core functions:

  - containsBadWords(comment): Uses the bad-words package to check for profanity.

  - countWords(comment): Counts words while ignoring emojis.

 - shouldCreateNotification(comment): Combines the above checks to determine if a reply qualifies for notification.

- Updated comments.js route to integrate these filters before triggering a notification for replies.

- Added test script to validate the filtering logic with a variety of edge cases (e.g., emoji-only, short comments, profanity).

- Implemented fallback mechanism: Ensures that even if bad-words fails or becomes incompatible, the system won’t break   it logs the issue and bypasses the profanity check gracefully.

- Created see-bad-words.js: A utility to log and review the word list from the bad-words package for internal moderation reference.