### PR TITLE
[TC2] Notify/high group activity

### DIFF
--- a/backend/config/notification-config.js
+++ b/backend/config/notification-config.js
@@ -1,0 +1,13 @@
+/**
+ * Configuration settings for the notification system
+ */
+module.exports = {
+  // High activity threshold configuration
+  HIGH_ACTIVITY: {
+    // Number of distinct users required to trigger a high activity notification
+    DISTINCT_USERS_THRESHOLD: 5,
+
+    // Time window in minutes to check for high activity
+    TIME_WINDOW_MINUTES: 30,
+  },
+};

--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,0 +1,106 @@
+const { PrismaClient } = require("../generated/prisma");
+const { HIGH_ACTIVITY } = require("../config/notification-config");
+const prisma = new PrismaClient();
+
+/**
+ * checks if a channel has high activity based on configured thresholds
+ * @param {string} channelId - The ID of the channel to check
+ * @returns {Promise<boolean>} - True if the channel has high activity, false otherwise
+ */
+async function checkChannelActivity(channelId) {
+  try {
+    const timeThreshold = new Date();
+    timeThreshold.setMinutes(
+      timeThreshold.getMinutes() - HIGH_ACTIVITY.TIME_WINDOW_MINUTES
+    );
+
+    // get distinct users who have sent messages in the channel within the time window
+    const recentMessages = await prisma.message.findMany({
+      where: {
+        channelId: channelId,
+        createdAt: {
+          gte: timeThreshold,
+        },
+      },
+      select: {
+        userId: true,
+      },
+      distinct: ["userId"],
+    });
+
+    // count distinct users
+    const distinctUserCount = recentMessages.length;
+
+    console.log(
+      `Channel ${channelId} activity check: ${distinctUserCount}/${HIGH_ACTIVITY.DISTINCT_USERS_THRESHOLD} distinct users in the last ${HIGH_ACTIVITY.TIME_WINDOW_MINUTES} minutes`
+    );
+
+    // return true if the number of distinct users meets or exceeds the threshold
+    return distinctUserCount >= HIGH_ACTIVITY.DISTINCT_USERS_THRESHOLD;
+  } catch (error) {
+    console.error("Error checking channel activity:", error);
+    // default to false if there's an error
+    return false;
+  }
+}
+
+/**
+ * this creates notifications for channel members about high activity
+ * @param {string} channelId - the ID of the channel with high activity
+ * @param {number} senderId - the ID of the user who sent the latest message (to exclude from notifications)
+ * @param {string} messageId - the ID of the latest message
+ * @returns {Promise<void>}
+ */
+async function createHighActivityNotifications(channelId, senderId, messageId) {
+  try {
+    // get channel information
+    const channel = await prisma.channel.findUnique({
+      where: {
+        id: channelId,
+      },
+    });
+
+    if (!channel) {
+      console.error(`Channel ${channelId} not found`);
+      return;
+    }
+
+    // get all users in the channel except the message sender
+    const channelMembers = await prisma.userChannel.findMany({
+      where: {
+        channel_id: channelId,
+        user_id: {
+          not: senderId, // exclude the message sender
+        },
+      },
+      select: {
+        user_id: true,
+      },
+    });
+
+    // create notifications for all channel members
+    const notificationContent = `Active discussion happening in ${channel.book_title}! ${HIGH_ACTIVITY.DISTINCT_USERS_THRESHOLD}+ people are discussing this book right now. Join the conversation!`;
+
+    if (channelMembers.length > 0) {
+      await prisma.notification.createMany({
+        data: channelMembers.map((member) => ({
+          user_id: member.user_id,
+          channel_id: channelId,
+          message_id: messageId,
+          content: notificationContent,
+          is_read: false,
+        })),
+      });
+      console.log(
+        `Created high activity notifications for ${channelMembers.length} members in channel ${channelId}`
+      );
+    }
+  } catch (error) {
+    console.error("Error creating high activity notifications:", error);
+  }
+}
+
+module.exports = {
+  checkChannelActivity,
+  createHighActivityNotifications,
+};

--- a/frontend/src/pages/FavoritesPage.jsx
+++ b/frontend/src/pages/FavoritesPage.jsx
@@ -8,6 +8,7 @@ import "./FavoritesPage.css";
 function FavoritesPage() {
   const [favorites, setFavorites] = useState([]);
   const [shelfItems, setShelfItems] = useState(new Set());
+  const [joinedChannels, setJoinedChannels] = useState(new Set());
   const [loading, setLoading] = useState(true);
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -16,9 +17,11 @@ function FavoritesPage() {
     if (user) {
       loadFavorites();
       loadShelfItems();
+      loadJoinedChannels();
     } else {
       setFavorites([]);
       setShelfItems(new Set());
+      setJoinedChannels(new Set());
       setLoading(false);
     }
   }, [user]);
@@ -86,6 +89,94 @@ function FavoritesPage() {
         setFavorites((prev) => prev.filter((fav) => fav.book_id !== book.id));
       } else {
         alert("Failed to remove from favorites. Please try again.");
+      }
+    } catch (error) {
+      alert("Network error. Please try again.");
+    }
+  };
+
+  const loadJoinedChannels = async () => {
+    if (!user) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:3000/api/user-channels/user/${user.id}`
+      );
+
+      if (response.ok) {
+        const channelsData = await response.json();
+        const channelIds = new Set(channelsData.map((channel) => channel.id));
+        setJoinedChannels(channelIds);
+      } else {
+        setJoinedChannels(new Set());
+      }
+    } catch (error) {
+      console.error("Error loading joined channels:", error);
+      setJoinedChannels(new Set());
+    }
+  };
+
+  const handleJoinDiscussion = async (book) => {
+    if (!user) return;
+
+    try {
+      const isJoined = joinedChannels.has(book.id);
+
+      if (isJoined) {
+        // Leave the channel
+        const response = await fetch(
+          "http://localhost:3000/api/user-channels/leave",
+          {
+            method: "DELETE",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              userId: user.id,
+              bookId: book.id,
+            }),
+          }
+        );
+
+        if (response.ok) {
+          setJoinedChannels((prev) => {
+            const newJoinedChannels = new Set(prev);
+            newJoinedChannels.delete(book.id);
+            return newJoinedChannels;
+          });
+        } else {
+          alert("Failed to leave discussion. Please try again.");
+        }
+      } else {
+        // Join the channel
+        const response = await fetch(
+          "http://localhost:3000/api/user-channels/join",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              userId: user.id,
+              bookId: book.id,
+              bookTitle: book.volumeInfo.title,
+              bookData: book,
+            }),
+          }
+        );
+
+        if (response.ok) {
+          setJoinedChannels((prev) => {
+            const newJoinedChannels = new Set(prev);
+            newJoinedChannels.add(book.id);
+            return newJoinedChannels;
+          });
+
+          // Navigate to the discussion page
+          navigate(`/discussion/${book.id}`);
+        } else {
+          alert("Failed to join discussion. Please try again.");
+        }
       }
     } catch (error) {
       alert("Network error. Please try again.");
@@ -198,7 +289,12 @@ function FavoritesPage() {
     <div className="favorites-page">
       <Sidebar />
       <div className="favorites-content">
-        <button className="favorites-previous" onClick={() => navigate("/dashboard")}>❮ Previous</button>
+        <button
+          className="favorites-previous"
+          onClick={() => navigate("/dashboard")}
+        >
+          ❮ Previous
+        </button>
 
         <div className="favorites-header">
           <h1>My Favorites ({favorites.length})</h1>
@@ -250,6 +346,8 @@ function FavoritesPage() {
                   toShelf={shelfItems.has(book.id)}
                   onToggleFavorite={() => handleRemoveFromFavorites(book)}
                   onToggleToShelf={() => handleToggleToShelf(book)}
+                  onJoinDiscussion={handleJoinDiscussion}
+                  isJoined={joinedChannels.has(book.id)}
                 />
               );
             })}


### PR DESCRIPTION
### Changes
In this pull request, I:
- Created notificationService.js:
  Centralized notification logic to send alerts only when high channel activity is detected (default: 5+ distinct users posting   within 30 minutes).

- Configurable Thresholds:
  Added notification-config.js to allow easy tuning of user count and time window thresholds for triggering notifications.

- Updated Message Route Logic:
  Replaced immediate notification creation with the new activity-aware service. This improves signal-to-noise by avoiding unnecessary alerts during low engagement.

Initially users where unable to join a channel directly from the recommendations, shelf, or  favorites page. I fixed that issue in this PR as well.

### Test Plan
No UI Changes